### PR TITLE
Implemented event subscriber for Views Ajax Response

### DIFF
--- a/config/schema/views_autorefresh.views.schema.yml
+++ b/config/schema/views_autorefresh.views.schema.yml
@@ -33,6 +33,8 @@ views.area.views_autorefresh_area:
           type: string
         firstClass:
           type: string
+        lastClass:
+          type: string
         oddClass:
           type: string
         evenClass:

--- a/src/EventSubscriber/ViewsAjaxResponseSubscriber.php
+++ b/src/EventSubscriber/ViewsAjaxResponseSubscriber.php
@@ -28,7 +28,7 @@ class ViewsAjaxResponseSubscriber implements EventSubscriberInterface {
 
     $view = $event->getResponse()->getView();
     $autorefresh = views_autorefresh_get_settings($view);
-    if (isset($_REQUEST['autorefresh']) && isset($autorefresh)) {
+    if (\Drupal::request()->get('autorefresh') && isset($autorefresh)) {
       foreach ($response->getCommands() as $key => &$command) {
         if (!empty($autorefresh['incremental']) &&
           $command['command'] == 'insert' &&

--- a/src/EventSubscriber/ViewsAjaxResponseSubscriber.php
+++ b/src/EventSubscriber/ViewsAjaxResponseSubscriber.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Drupal\views_autorefresh\EventSubscriber;
+
+use Drupal\views\Ajax\ViewAjaxResponse;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Response subscriber to handle view ajax responses.
+ */
+class ViewsAjaxResponseSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Processes markup for HtmlResponse responses.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\FilterResponseEvent $event
+   *   The event to process.
+   */
+  public function onRespond(FilterResponseEvent $event) {
+    /** @var \Drupal\views\Ajax\ViewAjaxResponse $response */
+    $response = $event->getResponse();
+
+    if (!$response instanceof ViewAjaxResponse) {
+      return;
+    }
+
+    $view = $event->getResponse()->getView();
+    $autorefresh = views_autorefresh_get_settings($view);
+    if (isset($_REQUEST['autorefresh']) && isset($autorefresh)) {
+      foreach ($response->getCommands() as $key => &$command) {
+        if (!empty($autorefresh['incremental']) &&
+          $command['command'] == 'insert' &&
+          $command['selector'] == ('.view-dom-id-' . $view->dom_id)
+        ) {
+          $command['command'] = 'viewsAutoRefreshIncremental';
+          $command['view_name'] = $view->name . '-' . $view->current_display;
+        }
+        if ($command['command'] == 'viewsScrollTop') {
+          unset($response->getCommands()[$key]);
+        }
+      }
+      $timestamp = views_autorefresh_get_timestamp($view);
+      if ($timestamp) {
+        $response->getCommands()[] = array(
+          'command' => 'viewsAutoRefreshTriggerUpdate',
+          'selector' => '.view-dom-id-' . $view->dom_id,
+          'timestamp' => $timestamp,
+        );
+      }
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[KernelEvents::RESPONSE][] = ['onRespond', -200];
+    return $events;
+  }
+
+}

--- a/views_autorefresh.module
+++ b/views_autorefresh.module
@@ -7,35 +7,34 @@
 
 use Drupal\views\ViewExecutable;
 use Drupal\Core\Link;
+use Drupal\views\Views;
 
 /**
- * Implementation of hook_views_ajax_data_alter().
+ * Helper function to return view's "timestamp" - either real timestamp or max primary key in view rows.
  */
-function views_autorefresh_views_ajax_data_alter(&$commands, $view) {
-  $autorefresh = views_autorefresh_get_settings($view);
-  if (isset($_REQUEST['autorefresh']) && isset($autorefresh)) {
-    foreach ($commands as $key => &$command) {
-      if (
-        !empty($autorefresh['incremental']) &&
-        $command['command'] == 'insert' &&
-        $command['selector'] == ('.view-dom-id-' . $view->dom_id)
-      ) {
-        $command['command'] = 'viewsAutoRefreshIncremental';
-        $command['view_name'] = $view->name. '-' . $view->current_display;
-      }
-      if ($command['command'] == 'viewsScrollTop') {
-        unset($commands[$key]);
-      }
+function views_autorefresh_get_timestamp($view) {
+  $autorefresh = $view->header['autorefresh']->options;
+  if (empty($autorefresh)) {
+    return FALSE;
+  }
+  if (empty($autorefresh['incremental'])) {
+    return time();
+  }
+  foreach ($view->argument as $argument) {
+    $handler = Views::handlerManager($argument->field)->getHandler($argument->table, 'argument');
+    if ($handler->definition['handler'] == 'views_autorefresh_handler_argument_date') {
+      return time();
     }
-    $timestamp = views_autorefresh_get_timestamp($view);
-    if ($timestamp) {
-      $commands[] = array(
-        'command' => 'viewsAutoRefreshTriggerUpdate',
-        'selector' => '.view-dom-id-' . $view->dom_id,
-        'timestamp' => $timestamp,
-      );
+    elseif ($handler->definition['handler'] == 'views_autorefresh_handler_argument_base') {
+      // Find the max nid/uid/... of the result set.
+      $max_id = array_reduce($view->result, function ($max_id, $row) use ($view) {
+        return max($max_id, $row->{$view->base_field});
+      }, ~PHP_INT_MAX);
+      return $max_id === ~PHP_INT_MAX ? FALSE : $max_id;
     }
   }
+
+  return FALSE;
 }
 
 /**

--- a/views_autorefresh.services.yml
+++ b/views_autorefresh.services.yml
@@ -1,0 +1,6 @@
+services:
+  views_autorefresh.views_ajax_response_subscriber:
+    class: Drupal\views_autorefresh\EventSubscriber\ViewsAjaxResponseSubscriber
+    tags:
+      - { name: event_subscriber }
+    arguments: []


### PR DESCRIPTION
Not enough to fix the interval, but `hook_views_ajax_data_alter()` doesn't exist in Drupal 8. https://www.drupal.org/node/1843224 suggests to use event subscriber instead, so switched to that.

Also, ported necessary `views_autorefresh_get_timestamp()` from Drupal 7 and updated it according to: https://www.drupal.org/node/1907902.
